### PR TITLE
fix: pin speakeasyVersion in workflow.yaml

### DIFF
--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -1,5 +1,5 @@
 workflowVersion: 1.0.0
-speakeasyVersion: latest
+speakeasyVersion: v1.476.0
 sources:
     latest:
         inputs:


### PR DESCRIPTION
Pins the version of the Speakeasy CLI to the last version that was able to successfully publish the SDK.